### PR TITLE
RHEL rpm spec: Add needed dependencies to jpeg libraries.

### DIFF
--- a/redhat/jpeginfo.spec
+++ b/redhat/jpeginfo.spec
@@ -7,6 +7,8 @@ Group: Applications/Multimedia
 URL: http://www.iki.fi/tjko/projects.html
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-buildroot
+BuildRequires: libjpeg-turbo-devel
+Requires: libjpeg-turbo
 
 %description
 Jpeginfo prints information and tests integrity of JPEG/JFIF


### PR DESCRIPTION
Hi,

The RHEL rpm spec file missed the needed dependencies to the JPEG libraries. I added them.
Just a small change, maybe you'll merge it -- then I can discard my fork. :-)

Cheers, and thanks for that code,
Joachim