### PR TITLE
cleanup: Remove trailing spaces

### DIFF
--- a/getopt.c
+++ b/getopt.c
@@ -19,7 +19,7 @@
    You should have received a copy of the GNU General Public License
    along with this program; if not, write to the Free Software
    Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
-
+
 /* This tells Alpha OSF/1 not to define a getopt prototype in <stdio.h>.
    Ditto for AIX 3.2 and <stdlib.h>.  */
 #ifndef _NO_PROTO
@@ -165,7 +165,7 @@ static enum
 
 /* Value of POSIXLY_CORRECT environment variable.  */
 static char *posixly_correct;
-
+
 #ifdef	__GNU_LIBRARY__
 /* We want to avoid inclusion of string.h with non-GNU libraries
    because there are many ways it can cause trouble.
@@ -207,7 +207,7 @@ extern int strlen (const char *);
 #endif /* __GNUC__ */
 
 #endif /* not __GNU_LIBRARY__ */
-
+
 /* Handle permutation of arguments.  */
 
 /* Describe the part of ARGV that contains non-options that have
@@ -317,7 +317,7 @@ _getopt_initialize (optstring)
 
   return optstring;
 }
-
+
 /* Scan elements of ARGV (whose length is ARGC) for option characters
    given in OPTSTRING.
 
@@ -685,7 +685,7 @@ getopt (argc, argv, optstring)
 }
 
 #endif	/* _LIBC or not __GNU_LIBRARY__.  */
-
+
 #ifdef TEST
 
 /* Compile with -DTEST to make an executable for use in testing

--- a/getopt1.c
+++ b/getopt1.c
@@ -15,7 +15,7 @@
    You should have received a copy of the GNU General Public License
    along with this program; if not, write to the Free Software
    Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.  */
-
+
 #ifdef HAVE_CONFIG_H
 #if defined (emacs) || defined (CONFIG_BROKETS)
 /* We use <config.h> instead of "config.h" so that a compilation
@@ -91,7 +91,7 @@ getopt_long_only (argc, argv, options, long_options, opt_index)
 
 
 #endif	/* _LIBC or not __GNU_LIBRARY__.  */
-
+
 #ifdef TEST
 
 #include <stdio.h>

--- a/md5/md5.c
+++ b/md5/md5.c
@@ -123,7 +123,7 @@ MD5Update(ctx, buf, len)
 }
 
 /*
- * Final wrapup - pad to 64-byte boundary with the bit pattern 
+ * Final wrapup - pad to 64-byte boundary with the bit pattern
  * 1 0* (64-bit count of bits processed, MSB-first)
  */
 void

--- a/sha256/blocks.c
+++ b/sha256/blocks.c
@@ -185,7 +185,7 @@ int crypto_hashblocks_sha256_ref(unsigned char *statebytes,const unsigned char *
     f += state[5];
     g += state[6];
     h += state[7];
-  
+
     state[0] = a;
     state[1] = b;
     state[2] = c;

--- a/sha512/blocks.c
+++ b/sha512/blocks.c
@@ -212,7 +212,7 @@ int crypto_hashblocks_sha512_ref(unsigned char *statebytes,const unsigned char *
     f += state[5];
     g += state[6];
     h += state[7];
-  
+
     state[0] = a;
     state[1] = b;
     state[2] = c;


### PR DESCRIPTION
```
find . -name "*.[ch]" | xargs perl -pi -e 's/\s+\n/\n/g'
```