### PR TITLE
Remove PROTO and NO_PROTO macros.

### DIFF
--- a/getopt.c
+++ b/getopt.c
@@ -22,9 +22,6 @@
 
 /* This tells Alpha OSF/1 not to define a getopt prototype in <stdio.h>.
    Ditto for AIX 3.2 and <stdlib.h>.  */
-#ifndef _NO_PROTO
-#define _NO_PROTO
-#endif
 
 #ifdef HAVE_CONFIG_H
 #if defined (emacs) || defined (CONFIG_BROKETS)

--- a/md5/md5.c
+++ b/md5/md5.c
@@ -21,24 +21,15 @@
 #include <string.h>	/* for memcpy() */
 #endif
 
-/* Add prototype support.  */
-#ifndef PROTO
-#if defined (USE_PROTOTYPES) ? USE_PROTOTYPES : defined (__STDC__)
-#define PROTO(ARGS) ARGS
-#else
-#define PROTO(ARGS) ()
-#endif
-#endif
-
 #include "md5.h"
 
-void byteReverse PROTO ((unsigned char *buf, unsigned longs));
+void byteReverse(unsigned char *buf, unsigned longs);
 
 #ifndef ASM_MD5
 /*
  * Note: this code is harmless on little-endian machines.
  */
-void byteReverse (unsigned char *buf, unsigned longs)
+void byteReverse(unsigned char *buf, unsigned longs)
 {
 	uint32 t;
 	do {

--- a/md5/md5.h
+++ b/md5/md5.h
@@ -12,27 +12,16 @@ a 32-bit integer type!  (Or maybe you just need to reconfigure.)
 #endif
 #endif
 
-/* Add prototype support.  */
-#ifndef PROTO
-#if defined (USE_PROTOTYPES) ? USE_PROTOTYPES : defined (__STDC__)
-#define PROTO(ARGS) ARGS
-#else
-#define PROTO(ARGS) ()
-#endif
-#endif
-
-
-
 struct MD5Context {
 	uint32 buf[4];
 	uint32 bits[2];
 	unsigned char in[64];
 };
 
-void MD5Init PROTO((struct MD5Context *context));
-void MD5Update PROTO((struct MD5Context *context, unsigned char const *buf, unsigned len));
-void MD5Final PROTO((unsigned char digest[16], struct MD5Context *context));
-void MD5Transform PROTO((uint32 buf[4], uint32 const in[16]));
+void MD5Init(struct MD5Context *context);
+void MD5Update(struct MD5Context *context, unsigned char const *buf, unsigned len);
+void MD5Final(unsigned char digest[16], struct MD5Context *context);
+void MD5Transform(uint32 buf[4], uint32 const in[16]);
 
 /*
  * This is needed to make RSAREF happy on some MS-DOS compilers.


### PR DESCRIPTION
Always use argument prototypes.