### PR TITLE
getopt.c md5.c: Remove register.

### DIFF
--- a/getopt.c
+++ b/getopt.c
@@ -243,7 +243,7 @@ exchange (argv)
 	{
 	  /* Bottom segment is the short one.  */
 	  int len = middle - bottom;
-	  register int i;
+	  int i;
 
 	  /* Swap it with the top part of the top segment.  */
 	  for (i = 0; i < len; i++)
@@ -259,7 +259,7 @@ exchange (argv)
 	{
 	  /* Top segment is the short one.  */
 	  int len = top - middle;
-	  register int i;
+	  int i;
 
 	  /* Swap it with the bottom part of the bottom segment.  */
 	  for (i = 0; i < len; i++)

--- a/md5/md5.c
+++ b/md5/md5.c
@@ -175,12 +175,10 @@ MD5Final(unsigned char digest[16], struct MD5Context *ctx)
 void
 MD5Transform(uint32 buf[4], uint32 const in[16])
 {
-	register uint32 a, b, c, d;
-
-	a = buf[0];
-	b = buf[1];
-	c = buf[2];
-	d = buf[3];
+	uint32 a = buf[0];
+	uint32 b = buf[1];
+	uint32 c = buf[2];
+	uint32 d = buf[3];
 
 	MD5STEP(F1, a, b, c, d, in[ 0]+0xd76aa478,  7);
 	MD5STEP(F1, d, a, b, c, in[ 1]+0xe8c7b756, 12);


### PR DESCRIPTION
`register` is no longer needed for modern compilers.