### PR TITLE
sha*/*.c: Minor cleanup

### DIFF
--- a/sha256/blocks.c
+++ b/sha256/blocks.c
@@ -5,9 +5,9 @@ typedef unsigned int uint32;
 static uint32 load_bigendian(const unsigned char *x)
 {
   return
-      (uint32) (x[3]) \
-  | (((uint32) (x[2])) << 8) \
-  | (((uint32) (x[1])) << 16) \
+      (uint32) (x[3])
+  | (((uint32) (x[2])) << 8)
+  | (((uint32) (x[1])) << 16)
   | (((uint32) (x[0])) << 24)
   ;
 }
@@ -64,26 +64,19 @@ static void store_bigendian(unsigned char *x,uint32 u)
 
 int crypto_hashblocks_sha256_ref(unsigned char *statebytes,const unsigned char *in,unsigned long long inlen)
 {
-  uint32 state[8];
-  uint32 a;
-  uint32 b;
-  uint32 c;
-  uint32 d;
-  uint32 e;
-  uint32 f;
-  uint32 g;
-  uint32 h;
   uint32 T1;
   uint32 T2;
 
-  a = load_bigendian(statebytes +  0); state[0] = a;
-  b = load_bigendian(statebytes +  4); state[1] = b;
-  c = load_bigendian(statebytes +  8); state[2] = c;
-  d = load_bigendian(statebytes + 12); state[3] = d;
-  e = load_bigendian(statebytes + 16); state[4] = e;
-  f = load_bigendian(statebytes + 20); state[5] = f;
-  g = load_bigendian(statebytes + 24); state[6] = g;
-  h = load_bigendian(statebytes + 28); state[7] = h;
+  uint32 a = load_bigendian(statebytes +  0);
+  uint32 b = load_bigendian(statebytes +  4);
+  uint32 c = load_bigendian(statebytes +  8);
+  uint32 d = load_bigendian(statebytes + 12);
+  uint32 e = load_bigendian(statebytes + 16);
+  uint32 f = load_bigendian(statebytes + 20);
+  uint32 g = load_bigendian(statebytes + 24);
+  uint32 h = load_bigendian(statebytes + 28);
+
+  uint32 state[8] = {a, b, c, d, e, f, g, h};
 
   while (inlen >= 64) {
     uint32 w0  = load_bigendian(in +  0);

--- a/sha256/hash.c
+++ b/sha256/hash.c
@@ -24,23 +24,22 @@ static const char iv[32] = {
 
 int crypto_hash_sha256(unsigned char *out,const unsigned char *in,unsigned long long inlen)
 {
-  unsigned char h[32];
-  unsigned char padded[128];
-  int i;
-  unsigned long long bits = inlen << 3;
+  const unsigned long long bits = inlen << 3;
 
-  for (i = 0;i < 32;++i) h[i] = iv[i];
+  unsigned char h[32];
+  for (int i = 0;i < 32;++i) h[i] = iv[i];
 
   blocks(h,in,inlen);
   in += inlen;
   inlen &= 63;
   in -= inlen;
 
-  for (i = 0;i < inlen;++i) padded[i] = in[i];
+  unsigned char padded[128];
+  for (int i = 0;i < inlen;++i) padded[i] = in[i];
   padded[inlen] = 0x80;
 
   if (inlen < 56) {
-    for (i = inlen + 1;i < 56;++i) padded[i] = 0;
+    for (int i = inlen + 1;i < 56;++i) padded[i] = 0;
     padded[56] = bits >> 56;
     padded[57] = bits >> 48;
     padded[58] = bits >> 40;
@@ -51,7 +50,7 @@ int crypto_hash_sha256(unsigned char *out,const unsigned char *in,unsigned long 
     padded[63] = bits;
     blocks(h,padded,64);
   } else {
-    for (i = inlen + 1;i < 120;++i) padded[i] = 0;
+    for (int i = inlen + 1;i < 120;++i) padded[i] = 0;
     padded[120] = bits >> 56;
     padded[121] = bits >> 48;
     padded[122] = bits >> 40;
@@ -63,7 +62,7 @@ int crypto_hash_sha256(unsigned char *out,const unsigned char *in,unsigned long 
     blocks(h,padded,128);
   }
 
-  for (i = 0;i < 32;++i) out[i] = h[i];
+  for (int i = 0;i < 32;++i) out[i] = h[i];
 
   return 0;
 }

--- a/sha512/blocks.c
+++ b/sha512/blocks.c
@@ -5,13 +5,13 @@ typedef unsigned long long uint64;
 static uint64 load_bigendian(const unsigned char *x)
 {
   return
-      (uint64) (x[7]) \
-  | (((uint64) (x[6])) << 8) \
-  | (((uint64) (x[5])) << 16) \
-  | (((uint64) (x[4])) << 24) \
-  | (((uint64) (x[3])) << 32) \
-  | (((uint64) (x[2])) << 40) \
-  | (((uint64) (x[1])) << 48) \
+      (uint64) (x[7])
+  | (((uint64) (x[6])) << 8)
+  | (((uint64) (x[5])) << 16)
+  | (((uint64) (x[4])) << 24)
+  | (((uint64) (x[3])) << 32)
+  | (((uint64) (x[2])) << 40)
+  | (((uint64) (x[1])) << 48)
   | (((uint64) (x[0])) << 56)
   ;
 }
@@ -72,26 +72,19 @@ static void store_bigendian(unsigned char *x,uint64 u)
 
 int crypto_hashblocks_sha512_ref(unsigned char *statebytes,const unsigned char *in,unsigned long long inlen)
 {
-  uint64 state[8];
-  uint64 a;
-  uint64 b;
-  uint64 c;
-  uint64 d;
-  uint64 e;
-  uint64 f;
-  uint64 g;
-  uint64 h;
   uint64 T1;
   uint64 T2;
 
-  a = load_bigendian(statebytes +  0); state[0] = a;
-  b = load_bigendian(statebytes +  8); state[1] = b;
-  c = load_bigendian(statebytes + 16); state[2] = c;
-  d = load_bigendian(statebytes + 24); state[3] = d;
-  e = load_bigendian(statebytes + 32); state[4] = e;
-  f = load_bigendian(statebytes + 40); state[5] = f;
-  g = load_bigendian(statebytes + 48); state[6] = g;
-  h = load_bigendian(statebytes + 56); state[7] = h;
+  uint64 a = load_bigendian(statebytes +  0);
+  uint64 b = load_bigendian(statebytes +  8);
+  uint64 c = load_bigendian(statebytes + 16);
+  uint64 d = load_bigendian(statebytes + 24);
+  uint64 e = load_bigendian(statebytes + 32);
+  uint64 f = load_bigendian(statebytes + 40);
+  uint64 g = load_bigendian(statebytes + 48);
+  uint64 h = load_bigendian(statebytes + 56);
+
+  uint64 state[8] = {a, b, c, d, e, f, g, h};
 
   while (inlen >= 128) {
     uint64 w0  = load_bigendian(in +   0);

--- a/sha512/hash.c
+++ b/sha512/hash.c
@@ -26,21 +26,20 @@ int crypto_hash_sha512(unsigned char *out,const unsigned char *in,unsigned long 
 {
   unsigned char h[64];
   unsigned char padded[256];
-  int i;
   unsigned long long bytes = inlen;
 
-  for (i = 0;i < 64;++i) h[i] = iv[i];
+  for (int i = 0;i < 64;++i) h[i] = iv[i];
 
   blocks(h,in,inlen);
   in += inlen;
   inlen &= 127;
   in -= inlen;
 
-  for (i = 0;i < inlen;++i) padded[i] = in[i];
+  for (int i = 0;i < inlen;++i) padded[i] = in[i];
   padded[inlen] = 0x80;
 
   if (inlen < 112) {
-    for (i = inlen + 1;i < 119;++i) padded[i] = 0;
+    for (int i = inlen + 1;i < 119;++i) padded[i] = 0;
     padded[119] = bytes >> 61;
     padded[120] = bytes >> 53;
     padded[121] = bytes >> 45;
@@ -52,7 +51,7 @@ int crypto_hash_sha512(unsigned char *out,const unsigned char *in,unsigned long 
     padded[127] = bytes << 3;
     blocks(h,padded,128);
   } else {
-    for (i = inlen + 1;i < 247;++i) padded[i] = 0;
+    for (int i = inlen + 1;i < 247;++i) padded[i] = 0;
     padded[247] = bytes >> 61;
     padded[248] = bytes >> 53;
     padded[249] = bytes >> 45;
@@ -65,7 +64,7 @@ int crypto_hash_sha512(unsigned char *out,const unsigned char *in,unsigned long 
     blocks(h,padded,256);
   }
 
-  for (i = 0;i < 64;++i) out[i] = h[i];
+  for (int i = 0;i < 64;++i) out[i] = h[i];
 
   return 0;
 }


### PR DESCRIPTION
- Remove unnecessary escaping of line ending in functions
- Combine definition and initialization of variables
- Simplify initialization of state