### PR TITLE
md5 and	sha*: Use stdint.h for uint32_t	and uint64_t

### DIFF
--- a/md5/md5.c
+++ b/md5/md5.c
@@ -15,6 +15,8 @@
  * will fill a supplied 16-byte array with the digest.
  */
 
+#include <stdint.h>
+
 #include "config.h"
 
 #if HAVE_STRING_H || STDC_HEADERS
@@ -31,11 +33,11 @@ void byteReverse(unsigned char *buf, unsigned longs);
  */
 void byteReverse(unsigned char *buf, unsigned longs)
 {
-	uint32 t;
+	uint32_t t;
 	do {
-		t = (uint32)((unsigned)buf[3]<<8 | buf[2]) << 16 |
+		t = (uint32_t)((unsigned)buf[3]<<8 | buf[2]) << 16 |
 		            ((unsigned)buf[1]<<8 | buf[0]);
-		*(uint32 *)buf = t;
+		*(uint32_t *)buf = t;
 		buf += 4;
 	} while (--longs);
 }
@@ -64,12 +66,12 @@ MD5Init(struct MD5Context *ctx)
 void
 MD5Update(struct MD5Context *ctx, unsigned char const *buf, unsigned len)
 {
-	uint32 t;
+	uint32_t t;
 
 	/* Update bitcount */
 
 	t = ctx->bits[0];
-	if ((ctx->bits[0] = t + ((uint32)len << 3)) < t)
+	if ((ctx->bits[0] = t + ((uint32_t)len << 3)) < t)
 		ctx->bits[1]++;	/* Carry from low to high */
 	ctx->bits[1] += len >> 29;
 
@@ -87,7 +89,7 @@ MD5Update(struct MD5Context *ctx, unsigned char const *buf, unsigned len)
 		}
 		memcpy(p, buf, t);
 		byteReverse(ctx->in, 16);
-		MD5Transform(ctx->buf, (uint32 *)ctx->in);
+		MD5Transform(ctx->buf, (uint32_t *)ctx->in);
 		buf += t;
 		len -= t;
 	}
@@ -97,7 +99,7 @@ MD5Update(struct MD5Context *ctx, unsigned char const *buf, unsigned len)
 	while (len >= 64) {
 		memcpy(ctx->in, buf, 64);
 		byteReverse(ctx->in, 16);
-		MD5Transform(ctx->buf, (uint32 *)ctx->in);
+		MD5Transform(ctx->buf, (uint32_t *)ctx->in);
 		buf += 64;
 		len -= 64;
 	}
@@ -133,7 +135,7 @@ MD5Final(unsigned char digest[16], struct MD5Context *ctx)
 		/* Two lots of padding:  Pad the first block to 64 bytes */
 		memset(p, 0, count);
 		byteReverse(ctx->in, 16);
-		MD5Transform(ctx->buf, (uint32 *)ctx->in);
+		MD5Transform(ctx->buf, (uint32_t *)ctx->in);
 
 		/* Now fill the next block with 56 bytes */
 		memset(ctx->in, 0, 56);
@@ -144,10 +146,10 @@ MD5Final(unsigned char digest[16], struct MD5Context *ctx)
 	byteReverse(ctx->in, 14);
 
 	/* Append length in bits and transform */
-	((uint32 *)ctx->in)[ 14 ] = ctx->bits[0];
-	((uint32 *)ctx->in)[ 15 ] = ctx->bits[1];
+	((uint32_t *)ctx->in)[ 14 ] = ctx->bits[0];
+	((uint32_t *)ctx->in)[ 15 ] = ctx->bits[1];
 
-	MD5Transform(ctx->buf, (uint32 *)ctx->in);
+	MD5Transform(ctx->buf, (uint32_t *)ctx->in);
 	byteReverse((unsigned char *)ctx->buf, 4);
 	memcpy(digest, ctx->buf, 16);
 	memset(ctx, 0, sizeof(*ctx));	/* In case it's sensitive */
@@ -173,12 +175,12 @@ MD5Final(unsigned char digest[16], struct MD5Context *ctx)
  * the data and converts bytes into longwords for this routine.
  */
 void
-MD5Transform(uint32 buf[4], uint32 const in[16])
+MD5Transform(uint32_t buf[4], uint32_t const in[16])
 {
-	uint32 a = buf[0];
-	uint32 b = buf[1];
-	uint32 c = buf[2];
-	uint32 d = buf[3];
+	uint32_t a = buf[0];
+	uint32_t b = buf[1];
+	uint32_t c = buf[2];
+	uint32_t d = buf[3];
 
 	MD5STEP(F1, a, b, c, d, in[ 0]+0xd76aa478,  7);
 	MD5STEP(F1, d, a, b, c, in[ 1]+0xe8c7b756, 12);

--- a/md5/md5.h
+++ b/md5/md5.h
@@ -1,27 +1,18 @@
 #ifndef MD5_H
 #define MD5_H
 
-#if SIZEOF_LONG == 4
-typedef unsigned long uint32;
-#else
-#if SIZEOF_INT == 4
-typedef unsigned int uint32;
-#else
-Congratulations!  You get to rewrite this code so that it does not require
-a 32-bit integer type!  (Or maybe you just need to reconfigure.)
-#endif
-#endif
+#include <stdint.h>
 
 struct MD5Context {
-	uint32 buf[4];
-	uint32 bits[2];
+	uint32_t buf[4];
+	uint32_t bits[2];
 	unsigned char in[64];
 };
 
 void MD5Init(struct MD5Context *context);
 void MD5Update(struct MD5Context *context, unsigned char const *buf, unsigned len);
 void MD5Final(unsigned char digest[16], struct MD5Context *context);
-void MD5Transform(uint32 buf[4], uint32 const in[16]);
+void MD5Transform(uint32_t buf[4], uint32_t const in[16]);
 
 /*
  * This is needed to make RSAREF happy on some MS-DOS compilers.

--- a/sha256/blocks.c
+++ b/sha256/blocks.c
@@ -1,18 +1,19 @@
+#include <stdint.h>
+
 #include "crypto_hashblocks_sha256.h"
 
-typedef unsigned int uint32;
 
-static uint32 load_bigendian(const unsigned char *x)
+static uint32_t load_bigendian(const unsigned char *x)
 {
   return
-      (uint32) (x[3])
-  | (((uint32) (x[2])) << 8)
-  | (((uint32) (x[1])) << 16)
-  | (((uint32) (x[0])) << 24)
+      (uint32_t) (x[3])
+  | (((uint32_t) (x[2])) << 8)
+  | (((uint32_t) (x[1])) << 16)
+  | (((uint32_t) (x[0])) << 24)
   ;
 }
 
-static void store_bigendian(unsigned char *x,uint32 u)
+static void store_bigendian(unsigned char *x,uint32_t u)
 {
   x[3] = u; u >>= 8;
   x[2] = u; u >>= 8;
@@ -64,37 +65,37 @@ static void store_bigendian(unsigned char *x,uint32 u)
 
 int crypto_hashblocks_sha256_ref(unsigned char *statebytes,const unsigned char *in,unsigned long long inlen)
 {
-  uint32 T1;
-  uint32 T2;
+  uint32_t T1;
+  uint32_t T2;
 
-  uint32 a = load_bigendian(statebytes +  0);
-  uint32 b = load_bigendian(statebytes +  4);
-  uint32 c = load_bigendian(statebytes +  8);
-  uint32 d = load_bigendian(statebytes + 12);
-  uint32 e = load_bigendian(statebytes + 16);
-  uint32 f = load_bigendian(statebytes + 20);
-  uint32 g = load_bigendian(statebytes + 24);
-  uint32 h = load_bigendian(statebytes + 28);
+  uint32_t a = load_bigendian(statebytes +  0);
+  uint32_t b = load_bigendian(statebytes +  4);
+  uint32_t c = load_bigendian(statebytes +  8);
+  uint32_t d = load_bigendian(statebytes + 12);
+  uint32_t e = load_bigendian(statebytes + 16);
+  uint32_t f = load_bigendian(statebytes + 20);
+  uint32_t g = load_bigendian(statebytes + 24);
+  uint32_t h = load_bigendian(statebytes + 28);
 
-  uint32 state[8] = {a, b, c, d, e, f, g, h};
+  uint32_t state[8] = {a, b, c, d, e, f, g, h};
 
   while (inlen >= 64) {
-    uint32 w0  = load_bigendian(in +  0);
-    uint32 w1  = load_bigendian(in +  4);
-    uint32 w2  = load_bigendian(in +  8);
-    uint32 w3  = load_bigendian(in + 12);
-    uint32 w4  = load_bigendian(in + 16);
-    uint32 w5  = load_bigendian(in + 20);
-    uint32 w6  = load_bigendian(in + 24);
-    uint32 w7  = load_bigendian(in + 28);
-    uint32 w8  = load_bigendian(in + 32);
-    uint32 w9  = load_bigendian(in + 36);
-    uint32 w10 = load_bigendian(in + 40);
-    uint32 w11 = load_bigendian(in + 44);
-    uint32 w12 = load_bigendian(in + 48);
-    uint32 w13 = load_bigendian(in + 52);
-    uint32 w14 = load_bigendian(in + 56);
-    uint32 w15 = load_bigendian(in + 60);
+    uint32_t w0  = load_bigendian(in +  0);
+    uint32_t w1  = load_bigendian(in +  4);
+    uint32_t w2  = load_bigendian(in +  8);
+    uint32_t w3  = load_bigendian(in + 12);
+    uint32_t w4  = load_bigendian(in + 16);
+    uint32_t w5  = load_bigendian(in + 20);
+    uint32_t w6  = load_bigendian(in + 24);
+    uint32_t w7  = load_bigendian(in + 28);
+    uint32_t w8  = load_bigendian(in + 32);
+    uint32_t w9  = load_bigendian(in + 36);
+    uint32_t w10 = load_bigendian(in + 40);
+    uint32_t w11 = load_bigendian(in + 44);
+    uint32_t w12 = load_bigendian(in + 48);
+    uint32_t w13 = load_bigendian(in + 52);
+    uint32_t w14 = load_bigendian(in + 56);
+    uint32_t w15 = load_bigendian(in + 60);
 
     F(w0 ,0x428a2f98)
     F(w1 ,0x71374491)

--- a/sha256/hash.c
+++ b/sha256/hash.c
@@ -9,8 +9,6 @@ Public domain.
 
 #define blocks crypto_hashblocks_sha256
 
-typedef unsigned int uint32;
-
 static const char iv[32] = {
   0x6a,0x09,0xe6,0x67,
   0xbb,0x67,0xae,0x85,

--- a/sha512/blocks.c
+++ b/sha512/blocks.c
@@ -1,22 +1,22 @@
 #include "crypto_hashblocks_sha512.h"
 
-typedef unsigned long long uint64;
+#include <stdint.h>
 
-static uint64 load_bigendian(const unsigned char *x)
+static uint64_t load_bigendian(const unsigned char *x)
 {
   return
-      (uint64) (x[7])
-  | (((uint64) (x[6])) << 8)
-  | (((uint64) (x[5])) << 16)
-  | (((uint64) (x[4])) << 24)
-  | (((uint64) (x[3])) << 32)
-  | (((uint64) (x[2])) << 40)
-  | (((uint64) (x[1])) << 48)
-  | (((uint64) (x[0])) << 56)
+      (uint64_t) (x[7])
+  | (((uint64_t) (x[6])) << 8)
+  | (((uint64_t) (x[5])) << 16)
+  | (((uint64_t) (x[4])) << 24)
+  | (((uint64_t) (x[3])) << 32)
+  | (((uint64_t) (x[2])) << 40)
+  | (((uint64_t) (x[1])) << 48)
+  | (((uint64_t) (x[0])) << 56)
   ;
 }
 
-static void store_bigendian(unsigned char *x,uint64 u)
+static void store_bigendian(unsigned char *x,uint64_t u)
 {
   x[7] = u; u >>= 8;
   x[6] = u; u >>= 8;
@@ -72,37 +72,37 @@ static void store_bigendian(unsigned char *x,uint64 u)
 
 int crypto_hashblocks_sha512_ref(unsigned char *statebytes,const unsigned char *in,unsigned long long inlen)
 {
-  uint64 T1;
-  uint64 T2;
+  uint64_t T1;
+  uint64_t T2;
 
-  uint64 a = load_bigendian(statebytes +  0);
-  uint64 b = load_bigendian(statebytes +  8);
-  uint64 c = load_bigendian(statebytes + 16);
-  uint64 d = load_bigendian(statebytes + 24);
-  uint64 e = load_bigendian(statebytes + 32);
-  uint64 f = load_bigendian(statebytes + 40);
-  uint64 g = load_bigendian(statebytes + 48);
-  uint64 h = load_bigendian(statebytes + 56);
+  uint64_t a = load_bigendian(statebytes +  0);
+  uint64_t b = load_bigendian(statebytes +  8);
+  uint64_t c = load_bigendian(statebytes + 16);
+  uint64_t d = load_bigendian(statebytes + 24);
+  uint64_t e = load_bigendian(statebytes + 32);
+  uint64_t f = load_bigendian(statebytes + 40);
+  uint64_t g = load_bigendian(statebytes + 48);
+  uint64_t h = load_bigendian(statebytes + 56);
 
-  uint64 state[8] = {a, b, c, d, e, f, g, h};
+  uint64_t state[8] = {a, b, c, d, e, f, g, h};
 
   while (inlen >= 128) {
-    uint64 w0  = load_bigendian(in +   0);
-    uint64 w1  = load_bigendian(in +   8);
-    uint64 w2  = load_bigendian(in +  16);
-    uint64 w3  = load_bigendian(in +  24);
-    uint64 w4  = load_bigendian(in +  32);
-    uint64 w5  = load_bigendian(in +  40);
-    uint64 w6  = load_bigendian(in +  48);
-    uint64 w7  = load_bigendian(in +  56);
-    uint64 w8  = load_bigendian(in +  64);
-    uint64 w9  = load_bigendian(in +  72);
-    uint64 w10 = load_bigendian(in +  80);
-    uint64 w11 = load_bigendian(in +  88);
-    uint64 w12 = load_bigendian(in +  96);
-    uint64 w13 = load_bigendian(in + 104);
-    uint64 w14 = load_bigendian(in + 112);
-    uint64 w15 = load_bigendian(in + 120);
+    uint64_t w0  = load_bigendian(in +   0);
+    uint64_t w1  = load_bigendian(in +   8);
+    uint64_t w2  = load_bigendian(in +  16);
+    uint64_t w3  = load_bigendian(in +  24);
+    uint64_t w4  = load_bigendian(in +  32);
+    uint64_t w5  = load_bigendian(in +  40);
+    uint64_t w6  = load_bigendian(in +  48);
+    uint64_t w7  = load_bigendian(in +  56);
+    uint64_t w8  = load_bigendian(in +  64);
+    uint64_t w9  = load_bigendian(in +  72);
+    uint64_t w10 = load_bigendian(in +  80);
+    uint64_t w11 = load_bigendian(in +  88);
+    uint64_t w12 = load_bigendian(in +  96);
+    uint64_t w13 = load_bigendian(in + 104);
+    uint64_t w14 = load_bigendian(in + 112);
+    uint64_t w15 = load_bigendian(in + 120);
 
     F(w0 ,0x428a2f98d728ae22ULL)
     F(w1 ,0x7137449123ef65cdULL)

--- a/sha512/hash.c
+++ b/sha512/hash.c
@@ -20,8 +20,6 @@ static const unsigned char iv[64] = {
   0x5b,0xe0,0xcd,0x19,0x13,0x7e,0x21,0x79
 } ;
 
-typedef unsigned long long uint64;
-
 int crypto_hash_sha512(unsigned char *out,const unsigned char *in,unsigned long long inlen)
 {
   unsigned char h[64];


### PR DESCRIPTION
Made a quick test by hand:

Before:

```sh
for option in md5 sha256 sha512; do ./jpeginfo cover.jpg --$option ; done
cover.jpg                         147 x  147 24bit N JFIF                       20189 b8832777d98fea16a0ff35b06d212536        
cover.jpg                         147 x  147 24bit N JFIF                       20189 dfd70d65eb33dea306da1a307fb9f72630a21250bf728b41529762b12d0295e7        
cover.jpg                         147 x  147 24bit N JFIF                       20189 5b0bfbfe19403fa97eae08405284ece150db098f713151f0741e16a9c5dc4df7425eca8a926781911aaee08da6b0156824ec2e55391da512d40938f5fed5b6bb        
```

With the change:

```sh
for option in md5 sha256 sha512; do ./jpeginfo cover.jpg --$option ; done
cover.jpg                         147 x  147 24bit N JFIF                       20189 b8832777d98fea16a0ff35b06d212536        
cover.jpg                         147 x  147 24bit N JFIF                       20189 dfd70d65eb33dea306da1a307fb9f72630a21250bf728b41529762b12d0295e7        
cover.jpg                         147 x  147 24bit N JFIF                       20189 5b0bfbfe19403fa97eae08405284ece150db098f713151f0741e16a9c5dc4df7425eca8a926781911aaee08da6b0156824ec2e55391da512d40938f5fed5b6bb  
```

stdint.h is required as of C99.

See also:

- https://en.wikibooks.org/wiki/C_Programming/stdint.h
- https://cplusplus.com/reference/cstdint/
- https://pubs.opengroup.org/onlinepubs/9699919799/
- 