### PR TITLE
jpegmarker.h: Move extern to the front for jpeg_special_marker_type.

### DIFF
--- a/jpegmarker.h
+++ b/jpegmarker.h
@@ -14,9 +14,7 @@ struct jpeg_special_marker_type {
 	char *ident_str;
 };
 
-
-const extern struct jpeg_special_marker_type jpeg_special_marker_types[];
-
+extern const struct jpeg_special_marker_type jpeg_special_marker_types[];
 
 const char* jpeg_marker_name(unsigned int marker);
 const char* jpeg_special_marker_name(jpeg_saved_marker_ptr marker);


### PR DESCRIPTION
Found with `-Wextra` using gcc 13.2.0:

```
jpegmarker.h:18:1: warning: ‘extern’ is not at beginning of declaration [-Wold-style-declaration]
   18 | const extern struct jpeg_special_marker_type jpeg_special_marker_types[];
      | ^~~~~
```