### PR TITLE
Append -o flag explicitely in Makefile.in, to fix the build with BSD Make.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -61,6 +61,9 @@ OBJS = $(PKGNAME).o jpegmarker.o misc.o @GNUGETOPT@ \
 	sha256/hash.o sha256/blocks.o \
 	sha512/hash.o sha512/blocks.o
 
+.c.o:
+	$(CC) $(CFLAGS) -o $@ -c $<
+
 $(PKGNAME):	$(OBJS)
 	$(CC) $(CFLAGS) -o $(PKGNAME) $(OBJS) $(LDFLAGS) $(LIBS)
 


### PR DESCRIPTION
Otherwise hash.o and blocks.o are not generated in the 'sha256' and 'sha512' directories and linking fails.